### PR TITLE
Improve version locks of dependencies

### DIFF
--- a/sequel-enum_values.gemspec
+++ b/sequel-enum_values.gemspec
@@ -18,14 +18,13 @@ Gem::Specification.new do |s|
 
 	s.add_runtime_dependency 'sequel', '>= 4.1.0', '<= 6'
 
-	s.add_development_dependency 'codecov', '~> 0'
-	s.add_development_dependency 'pry', '~> 0'
+	s.add_development_dependency 'codecov', '~> 0.1.15'
 	s.add_development_dependency 'pry-byebug', '~> 3.5'
-	s.add_development_dependency 'rack-test', '~> 1'
-	s.add_development_dependency 'rake', '~> 13'
+	s.add_development_dependency 'rack-test', '~> 1.1'
+	s.add_development_dependency 'rake', '~> 13.0'
 	s.add_development_dependency 'rspec', '~> 3.7'
-	s.add_development_dependency 'rubocop', '~> 0.52'
-	s.add_development_dependency 'simplecov', '~> 0'
+	s.add_development_dependency 'rubocop', '~> 0.52.0'
+	s.add_development_dependency 'simplecov', '~> 0.17.1'
 
 	s.files = Dir[File.join('lib', '**', '*')]
 end


### PR DESCRIPTION
Remove extra `pry` dependency, required by `pry-byebug` dependency.