### PR TITLE
Fix coverage reports again

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 SimpleCov.start
 
-if ENV['CODECOV']
+if ENV['CODECOV_TOKEN']
 	require 'codecov'
 	SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
There was incorrect (old) environment variable name for Codecov sending.