### PR TITLE
Drop Ruby 2.3, add Ruby 2.7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,10 +12,10 @@ bundle_cache: &bundle_cache
 test_task:
   container:
     matrix:
-      image: ruby:2.3
       image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
+      image: ruby:2.7
   <<: *bundle_cache
   environment:
     CODECOV_TOKEN: ENCRYPTED[64e5f0046db773b1410165947fe5b33ef121a4181c60173ac6abc1e12354913e4dc7d41dec24b972b04022a42462f247]
@@ -23,6 +23,6 @@ test_task:
 
 rubocop_task:
   container:
-    image: ruby:2.6
+    image: ruby:2.7
   <<: *bundle_cache
   rubocop_script: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Layout/AlignArguments:
   EnforcedStyle: with_fixed_indentation
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
   Exclude:

--- a/sequel-enum_values.gemspec
+++ b/sequel-enum_values.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
 	s.homepage    = 'https://github.com/AlexWayfer/sequel-enum_values'
 	s.license     = 'MIT'
 
+	s.required_ruby_version = '>= 2.4.0'
+
 	s.add_runtime_dependency 'sequel', '>= 4.1.0', '<= 6'
 
 	s.add_development_dependency 'codecov', '~> 0.1.15'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/