### PR TITLE
Drop Codecov token from Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,8 +17,6 @@ test_task:
       image: ruby:2.6
       image: ruby:2.7
   <<: *bundle_cache
-  environment:
-    CODECOV_TOKEN: ENCRYPTED[64e5f0046db773b1410165947fe5b33ef121a4181c60173ac6abc1e12354913e4dc7d41dec24b972b04022a42462f247]
   test_script: bundle exec rake spec
 
 rubocop_task:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 SimpleCov.start
 
-if ENV['CODECOV_TOKEN']
+if ENV['CI']
 	require 'codecov'
 	SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
Now it's supported natively: https://github.com/codecov/codecov-bash/pull/127